### PR TITLE
Optimize resulting avatar image

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ $  npm i vue-avatar-cropper
  `upload-form-data` | Object | Additional form data, default: '{}'
  `upload-handler` | Function | Handler to replace default upload handler
  `upload-headers` | Object | Headers of upload request, default: `{}`
- `cropper-options` | Object | Options passed to [cropperJS](https://github.com/fengyuanchen/cropperjs#options) instance, default: `{aspectRatio: 1, autoCropArea: 1, viewMode: 1, movable: false, zoomable: false}`
- `output-options` | Object | Options passed to the [cropper.getCroppedCanvas()](https://github.com/fengyuanchen/cropperjs#getcroppedcanvasoptions) method, default: `{width: 512, height: 512}`
+ `cropper-options` | Object | Options passed to the [cropperJS](https://github.com/fengyuanchen/cropperjs#options) instance, <br>default: {<br>aspectRatio: 1, <br>autoCropArea: 1, <br>viewMode: 1, <br>movable: false, <br>zoomable: false<br>}
+ `output-options` | Object | Options passed to the [cropper.getCroppedCanvas()](https://github.com/fengyuanchen/cropperjs#getcroppedcanvasoptions) method, <br>default: `{width: 512, height: 512}`
  `output-mime` | String | The resulting avatar image mime type, default: `image/jpeg`
- `output-quality` | Number | The resulting avatar image quality [0 - 1] (if the output-mime property is `image/jpeg` or `image/webp`), default: `0.9`
+ `output-quality` | Number | The resulting avatar image quality [0 - 1], default: `0.9`<br>(if the output-mime property is `image/jpeg` or `image/webp`)
  `mimes` | String | Allowed image formats, default: <br>`image/png, image/gif, image/jpeg, image/bmp, image/x-icon`
  `labels` | Object | Label for buttons, default: `{ submit: "提交", cancel: "取消"}`
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ $  npm i vue-avatar-cropper
  `upload-form-data` | Object | Additional form data, default: '{}'
  `upload-handler` | Function | Handler to replace default upload handler
  `upload-headers` | Object | Headers of upload request, default: `{}`
+ `cropper-options` | Object | Options passed to [cropperJS](https://github.com/fengyuanchen/cropperjs#options) instance, default: `{aspectRatio: 1, autoCropArea: 1, viewMode: 1, movable: false, zoomable: false}`
  `output-options` | Object | Options passed to the [cropper.getCroppedCanvas()](https://github.com/fengyuanchen/cropperjs#getcroppedcanvasoptions) method, default: `{width: 512, height: 512}`
  `output-mime` | String | The resulting avatar image mime type, default: `image/jpeg`
  `output-quality` | Number | The resulting avatar image quality [0 - 1] (if the output-mime property is `image/jpeg` or `image/webp`), default: `0.9`

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ $  npm i vue-avatar-cropper
  `upload-form-data` | Object | Additional form data, default: '{}'
  `upload-handler` | Function | Handler to replace default upload handler
  `upload-headers` | Object | Headers of upload request, default: `{}`
+ `output-options` | Object | Options passed to the [cropper.getCroppedCanvas()](https://github.com/fengyuanchen/cropperjs#getcroppedcanvasoptions) method, default: `{width: 512, height: 512}`
+ `output-mime` | String | The resulting avatar image mime type, default: `image/jpeg`
+ `output-quality` | Number | The resulting avatar image quality [0 - 1] (if the output-mime property is `image/jpeg` or `image/webp`), default: `0.9`
  `mimes` | String | Allowed image formats, default: <br>`image/png, image/gif, image/jpeg, image/bmp, image/x-icon`
  `labels` | Object | Label for buttons, default: `{ submit: "提交", cancel: "取消"}`
 

--- a/src/AvatarCropper.vue
+++ b/src/AvatarCropper.vue
@@ -45,6 +45,23 @@
           return {}
         }
       },
+      outputOptions: {
+        type: Object,
+        default() {
+          return {
+            width: 512,
+            height: 512
+          }
+        }
+      },
+      outputMime: {
+        type: String,
+        default: 'image/jpeg'
+      },
+      outputQuality: {
+        type: Number,
+        default: 0.9
+      },
       mimes: {
         type: String,
         default: 'image/png, image/gif, image/jpeg, image/bmp, image/x-icon'
@@ -96,7 +113,7 @@
         })
       },
       uploadImage() {
-        this.cropper.getCroppedCanvas().toBlob((blob) => {
+        this.cropper.getCroppedCanvas(this.outputOptions).toBlob((blob) => {
           let form = new FormData()
           let xhr = new XMLHttpRequest()
           let data = Object.assign({}, this.uploadFormData)
@@ -133,7 +150,7 @@
             }
           }
           xhr.send(form);
-        })
+        }, this.outputMime, this.outputQuality)
       }
     },
     mounted() {

--- a/src/AvatarCropper.vue
+++ b/src/AvatarCropper.vue
@@ -45,6 +45,18 @@
           return {}
         }
       },
+      cropperOptions: {
+        type: Object,
+        default() {
+          return {
+            aspectRatio: 1,
+            autoCropArea: 1,
+            viewMode: 1,
+            movable: false,
+            zoomable: false,
+          }
+        }
+      },
       outputOptions: {
         type: Object,
         default() {
@@ -104,13 +116,7 @@
         this.$refs.input.click()
       },
       createCropper() {
-        this.cropper = new Cropper(this.$refs.img, {
-          aspectRatio: 1,
-          autoCropArea: 1,
-          viewMode: 1,
-          movable: false,
-          zoomable: false,
-        })
+        this.cropper = new Cropper(this.$refs.img, this.cropperOptions)
       },
       uploadImage() {
         this.cropper.getCroppedCanvas(this.outputOptions).toBlob((blob) => {


### PR DESCRIPTION
Hello ! It's me, ...again :grin: 

(This should be my last pull request as I finished what I was doing with this component ahah)

I noticed that the resulting avatar uploaded to my server was very huge because there was no limit to the size of the resulting image (if a user select a 4000 x 4000 px image, an avatar of about this size will be uploaded, in PNG format !! :scream:  ) so I did some tweaks to optimize that : 

- The resulting avatar is now a JPG by default (instead of a PNG)
- The size of it is limited to 512 x 512 px by default (instead of Infinite size)
- All the aboves :point_up: can be tweaked by the user using the new props I added

I used those as reference : 
- for the default JPG format : https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob
- for the size limit : https://github.com/fengyuanchen/cropperjs#getcroppedcanvasoptions

And if I understood the google translate output correctly, I think this PR will help with problems mentioned in issue #14 !