### PR TITLE
Have destroy method check whether this.cropper is defined

### DIFF
--- a/src/AvatarCropper.vue
+++ b/src/AvatarCropper.vue
@@ -132,7 +132,9 @@ export default {
   },
   methods: {
     destroy() {
-      this.cropper.destroy()
+      if (this.cropper) {
+        this.cropper.destroy()
+      }
       this.$refs.input.value = ''
       this.dataUrl = undefined
     },


### PR DESCRIPTION
Call this.cropper.destroy only if this.cropper is defined.

Prevents error "Cannot read property 'destroy' of undefined" when the
destroy method is called before createCropper which is not called until
the image has loaded.