### PR TITLE
Publish workflow should only run when PR is merged

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,9 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   build:
+    # This will only trigger the job on push, workflow_dispatch and on pull_request only if the pull request was merged, else it will skip the job
+    if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
**Changes**
- Made `publish` workflow only run on PR `closed` action type and made it skip job if PR was not merged