### PR TITLE
Fix: Use correct file field name option

### DIFF
--- a/src/vue-avatar-cropper.vue
+++ b/src/vue-avatar-cropper.vue
@@ -298,7 +298,7 @@ export default {
             form.append(key, value)
           }
 
-          form.append(this.uploadFormName, blob, this.filename)
+          form.append(this.uploadFileField, blob, this.filename)
 
           const requestOptions = Object.assign(
             {


### PR DESCRIPTION
Thanks for the latest improvements"

I noticed that the `upload-form-name` option is not accepted anymore but `upload-file-field` is not working correctly.